### PR TITLE
[2024/07/11] feat/signup >> 회원가입 기능 구현 및 security 구현

### DIFF
--- a/src/main/java/com/sparta/spartakanbanboard/domain/column/entity/KanbanColumn.java
+++ b/src/main/java/com/sparta/spartakanbanboard/domain/column/entity/KanbanColumn.java
@@ -8,7 +8,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @Entity
 @Table
-public class Column {
+public class KanbanColumn {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/sparta/spartakanbanboard/domain/column/repository/ColumnRepository.java
+++ b/src/main/java/com/sparta/spartakanbanboard/domain/column/repository/ColumnRepository.java
@@ -1,7 +1,7 @@
 package com.sparta.spartakanbanboard.domain.column.repository;
 
-import com.sparta.spartakanbanboard.domain.column.entity.Column;
+import com.sparta.spartakanbanboard.domain.column.entity.KanbanColumn;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface ColumnRepository extends JpaRepository<Column, Long> {
+public interface ColumnRepository extends JpaRepository<KanbanColumn, Long> {
 }

--- a/src/main/java/com/sparta/spartakanbanboard/domain/user/controller/UserController.java
+++ b/src/main/java/com/sparta/spartakanbanboard/domain/user/controller/UserController.java
@@ -1,14 +1,28 @@
 package com.sparta.spartakanbanboard.domain.user.controller;
 
+import com.sparta.spartakanbanboard.domain.user.dto.SignupRequestDto;
 import com.sparta.spartakanbanboard.domain.user.service.UserService;
+import com.sparta.spartakanbanboard.global.dto.CommonResponseDto;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping
+@RequestMapping("/api/users")
 @RequiredArgsConstructor
 public class UserController {
 
     private final UserService userService;
+
+    @PostMapping("/signup")
+    public ResponseEntity<CommonResponseDto> signup(@RequestBody @Valid SignupRequestDto signupRequestDto) {
+
+        CommonResponseDto responseDto = userService.signup(signupRequestDto);
+        return ResponseEntity.status(HttpStatus.OK).body(responseDto);
+    }
 }

--- a/src/main/java/com/sparta/spartakanbanboard/domain/user/dto/SignupRequestDto.java
+++ b/src/main/java/com/sparta/spartakanbanboard/domain/user/dto/SignupRequestDto.java
@@ -1,11 +1,16 @@
 package com.sparta.spartakanbanboard.domain.user.dto;
 
 import com.sparta.spartakanbanboard.domain.user.entity.UserRole;
+import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 
 @Getter
 public class SignupRequestDto {
+    @NotNull
     private String userName;
+    @NotNull
     private String password;
-    private UserRole userRole;
+    private String role = "";
+    private String adminToken = "";
+
 }

--- a/src/main/java/com/sparta/spartakanbanboard/domain/user/dto/SignupRequestDto.java
+++ b/src/main/java/com/sparta/spartakanbanboard/domain/user/dto/SignupRequestDto.java
@@ -1,9 +1,11 @@
 package com.sparta.spartakanbanboard.domain.user.dto;
 
+import com.sparta.spartakanbanboard.domain.user.entity.UserRole;
 import lombok.Getter;
 
 @Getter
 public class SignupRequestDto {
     private String userName;
     private String password;
+    private UserRole userRole;
 }

--- a/src/main/java/com/sparta/spartakanbanboard/domain/user/entity/User.java
+++ b/src/main/java/com/sparta/spartakanbanboard/domain/user/entity/User.java
@@ -1,16 +1,37 @@
 package com.sparta.spartakanbanboard.domain.user.entity;
 
 import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor
 @Entity
-@Table
+@Table(name = "db_user")
+@Builder
+@AllArgsConstructor
 public class User {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+
+    @Column(nullable = false, unique = true)
+    private String userName;
+
+    @Column(nullable = false)
+    private String password;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private UserRole userRole;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private UserStatus userStatus;
+
+    @Column
+    private String refreshToken;
 }

--- a/src/main/java/com/sparta/spartakanbanboard/domain/user/entity/User.java
+++ b/src/main/java/com/sparta/spartakanbanboard/domain/user/entity/User.java
@@ -8,10 +8,10 @@ import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor
+@AllArgsConstructor
+@Builder
 @Entity
 @Table(name = "db_user")
-@Builder
-@AllArgsConstructor
 public class User {
 
     @Id

--- a/src/main/java/com/sparta/spartakanbanboard/domain/user/entity/UserRole.java
+++ b/src/main/java/com/sparta/spartakanbanboard/domain/user/entity/UserRole.java
@@ -1,0 +1,6 @@
+package com.sparta.spartakanbanboard.domain.user.entity;
+
+public enum UserRole {
+    ADMIN,
+    USER
+}

--- a/src/main/java/com/sparta/spartakanbanboard/domain/user/entity/UserRole.java
+++ b/src/main/java/com/sparta/spartakanbanboard/domain/user/entity/UserRole.java
@@ -1,6 +1,21 @@
 package com.sparta.spartakanbanboard.domain.user.entity;
 
 public enum UserRole {
-    ADMIN,
-    USER
+    USER(Authority.USER),  // 사용자 권한
+    ADMIN(Authority.MANAGER);  // 관리자 권한
+
+    private final String authority;
+
+    UserRole(String authority) {
+        this.authority = authority;
+    }
+
+    public String getAuthority() {
+        return this.authority;
+    }
+
+    public static class Authority {
+        public static final String USER = "ROLE_USER";
+        public static final String MANAGER = "ROLE_MANAGER";
+    }
 }

--- a/src/main/java/com/sparta/spartakanbanboard/domain/user/entity/UserStatus.java
+++ b/src/main/java/com/sparta/spartakanbanboard/domain/user/entity/UserStatus.java
@@ -1,0 +1,6 @@
+package com.sparta.spartakanbanboard.domain.user.entity;
+
+public enum UserStatus {
+    ACTIVE,
+    LOGOUT
+}

--- a/src/main/java/com/sparta/spartakanbanboard/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/sparta/spartakanbanboard/domain/user/repository/UserRepository.java
@@ -3,5 +3,8 @@ package com.sparta.spartakanbanboard.domain.user.repository;
 import com.sparta.spartakanbanboard.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface UserRepository extends JpaRepository<User, Long> {
+    Optional<User> findByUserName(String userName);
 }

--- a/src/main/java/com/sparta/spartakanbanboard/domain/user/service/UserService.java
+++ b/src/main/java/com/sparta/spartakanbanboard/domain/user/service/UserService.java
@@ -1,12 +1,29 @@
 package com.sparta.spartakanbanboard.domain.user.service;
 
+import com.sparta.spartakanbanboard.domain.user.dto.SignupRequestDto;
+import com.sparta.spartakanbanboard.domain.user.entity.User;
+import com.sparta.spartakanbanboard.domain.user.entity.UserRole;
 import com.sparta.spartakanbanboard.domain.user.repository.UserRepository;
+import com.sparta.spartakanbanboard.global.dto.CommonResponseDto;
+import com.sparta.spartakanbanboard.global.jwt.JwtUtil;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
 public class UserService {
 
+    private final PasswordEncoder passwordEncoder;
     private final UserRepository userRepository;
+    private final JwtUtil jwtUtil;
+    @Value("${ADMIN_TOKEN}")
+    String adminToken;
+
+    public User findByUserId(Long userId) {
+        return userRepository.findById(userId).orElseThrow(() ->
+                new IllegalArgumentException("해당 유저를 찾을 수 없습니다"));
+    }
+
 }

--- a/src/main/java/com/sparta/spartakanbanboard/domain/user/service/UserService.java
+++ b/src/main/java/com/sparta/spartakanbanboard/domain/user/service/UserService.java
@@ -3,6 +3,7 @@ package com.sparta.spartakanbanboard.domain.user.service;
 import com.sparta.spartakanbanboard.domain.user.dto.SignupRequestDto;
 import com.sparta.spartakanbanboard.domain.user.entity.User;
 import com.sparta.spartakanbanboard.domain.user.entity.UserRole;
+import com.sparta.spartakanbanboard.domain.user.entity.UserStatus;
 import com.sparta.spartakanbanboard.domain.user.repository.UserRepository;
 import com.sparta.spartakanbanboard.global.dto.CommonResponseDto;
 import com.sparta.spartakanbanboard.global.jwt.JwtUtil;
@@ -20,6 +21,37 @@ public class UserService {
     private final JwtUtil jwtUtil;
     @Value("${ADMIN_TOKEN}")
     String adminToken;
+
+    public CommonResponseDto signup(SignupRequestDto signupRequestDto) {
+        String userName = signupRequestDto.getUserName();
+        String password = passwordEncoder.encode(signupRequestDto.getPassword());
+        UserRole userRole = UserRole.USER;
+
+        if (userRepository.findByUserName(userName).isPresent()) {
+            throw new RuntimeException("중복된 사용자 ID가 존재합니다.");
+        }
+
+        if (signupRequestDto.getRole().equals("ADMIN")) {
+            if (signupRequestDto.getAdminToken() != null && signupRequestDto.getAdminToken().equals(adminToken)) {
+                userRole = UserRole.ADMIN;
+            } else {
+                throw new IllegalArgumentException("adminToken이 올바르지 않습니다.");
+            }
+        }
+
+        User user = User.builder()
+                .userName(userName)
+                .password(password)
+                .userStatus(UserStatus.ACTIVE)
+                .userRole(userRole)
+                .build();
+
+        userRepository.save(user);
+
+        return CommonResponseDto.builder()
+                .msg("회원가입이 완료되었습니다.")
+                .build();
+    }
 
     public User findByUserId(Long userId) {
         return userRepository.findById(userId).orElseThrow(() ->

--- a/src/main/java/com/sparta/spartakanbanboard/global/config/PasswordConfig.java
+++ b/src/main/java/com/sparta/spartakanbanboard/global/config/PasswordConfig.java
@@ -1,0 +1,15 @@
+package com.sparta.spartakanbanboard.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@Configuration
+public class PasswordConfig {
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+}

--- a/src/main/java/com/sparta/spartakanbanboard/global/config/WebSecurityConfig.java
+++ b/src/main/java/com/sparta/spartakanbanboard/global/config/WebSecurityConfig.java
@@ -1,7 +1,58 @@
 package com.sparta.spartakanbanboard.global.config;
 
+import com.sparta.spartakanbanboard.global.jwt.JwtUtil;
+import com.sparta.spartakanbanboard.global.security.JwtAuthorizationFilter;
+import com.sparta.spartakanbanboard.global.security.UserDetailsServiceImpl;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 @Configuration
+@EnableWebSecurity // Spring Security 지원을 가능하게 함
+@RequiredArgsConstructor
 public class WebSecurityConfig {
+
+    private final JwtUtil jwtUtil;
+    private final UserDetailsServiceImpl userDetailsService;
+
+    @Bean
+    public AuthenticationManager authenticationManager(AuthenticationConfiguration configuration) throws Exception {
+        return configuration.getAuthenticationManager();
+    }
+
+    @Bean
+    public JwtAuthorizationFilter jwtAuthorizationFilter() {
+        return new JwtAuthorizationFilter(jwtUtil, userDetailsService);
+    }
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        // CSRF 설정
+        http.csrf((csrf) -> csrf.disable());
+
+        // 기본 설정인 Session 방식은 사용하지 않고 JWT 방식을 사용하기 위한 설정
+        http.sessionManagement((sessionManagement) ->
+                sessionManagement.sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+        );
+
+        http.authorizeHttpRequests((authorizeHttpRequests) ->
+                authorizeHttpRequests
+                        .requestMatchers("/").permitAll()
+                        .requestMatchers("/api/**").permitAll()
+                        .anyRequest().authenticated() // 그 외 모든 요청 인증처리
+        );
+
+        // 필터 관리
+        http.addFilterBefore(jwtAuthorizationFilter(), UsernamePasswordAuthenticationFilter.class);
+
+        return http.build();
+    }
 }

--- a/src/main/java/com/sparta/spartakanbanboard/global/dto/CommonResponseDto.java
+++ b/src/main/java/com/sparta/spartakanbanboard/global/dto/CommonResponseDto.java
@@ -1,16 +1,15 @@
 package com.sparta.spartakanbanboard.global.dto;
 import lombok.Builder;
-import lombok.Data;
 import lombok.Getter;
 
 @Getter
-public class CommonResDto<T> {
-    private int code;
+public class CommonResponseDto<T> {
+    private String msg;
     private T data;
 
     @Builder
-    public CommonResDto(int code, T data){
-        this.code = code;
+    public CommonResponseDto(String msg, T data){
+        this.msg = msg;
         this.data = data;
     }
 

--- a/src/main/java/com/sparta/spartakanbanboard/global/jwt/JwtUtil.java
+++ b/src/main/java/com/sparta/spartakanbanboard/global/jwt/JwtUtil.java
@@ -1,0 +1,116 @@
+package com.sparta.spartakanbanboard.global.jwt;
+
+import com.sparta.spartakanbanboard.domain.user.entity.UserRole;
+import io.jsonwebtoken.*;
+import io.jsonwebtoken.security.Keys;
+import jakarta.annotation.PostConstruct;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+import java.security.Key;
+import java.util.Base64;
+import java.util.Date;
+
+@Component
+public class JwtUtil {
+    // Access Token Header KEY 값
+    public static final String AUTHORIZATION_HEADER = "Authorization";
+    // Refresh Token Header KEY 값
+    public static final String REFRESH_HEADER = "refresh";
+    // 사용자 권한 값의 KEY
+    public static final String AUTHORIZATION_KEY = "auth";
+    // Token 식별자
+    public static final String BEARER_PREFIX = "Bearer ";
+    // AccessToken 만료시간 60분
+    private final long ACCESS_TOKEN_TIME = 10 * 60 * 60 * 1000L;
+    // RefreshToken 만료시간 14일
+    private final long REFRESHTOKEN_TIME = 14 * 24 * 60 * 60 * 1000L;
+
+    // Base64 Encode 한 SecretKey
+    @Value("${jwt.secret.key}")
+    private String secretKey;
+    private Key key;
+    private final SignatureAlgorithm signatureAlgorithm = SignatureAlgorithm.HS256;
+
+    // 로그 설정
+    public static final Logger logger = LoggerFactory.getLogger("JWT 관련 로그");
+
+    // 딱 한번만 받아오면 되는 값을 사용 할 때마다 새로 요청하는 실수를 방지하기 위한
+    @PostConstruct
+    public void init() {
+        byte[] bytes = Base64.getDecoder().decode(secretKey);
+        key = Keys.hmacShaKeyFor(bytes);
+    }
+
+    // 토큰 생성
+    public String createAccessToken(String userName, UserRole userRole) {
+        Date date = new Date();
+
+        return BEARER_PREFIX +
+                Jwts.builder()
+                        .setSubject(userName) // 사용자 식별자값(ID)
+                        .claim(AUTHORIZATION_KEY, userRole) // 사용자 권한
+                        .setExpiration(new Date(date.getTime() + ACCESS_TOKEN_TIME)) // 만료 시간
+                        .setIssuedAt(date) // 발급일
+                        .signWith(key, signatureAlgorithm) // 암호화 알고리즘
+                        .compact();
+    }
+
+    public String createRefreshToken(String userName, UserRole userRole) {
+        Date date = new Date();
+
+        return BEARER_PREFIX +
+                Jwts.builder()
+                        .setSubject(userName) // 사용자 식별자값(ID)
+                        .claim(AUTHORIZATION_KEY, userRole) // 사용자 권한
+                        .setExpiration(new Date(date.getTime() + REFRESHTOKEN_TIME)) // 만료 시간
+                        .setIssuedAt(date) // 발급일
+                        .signWith(key, signatureAlgorithm) // 암호화 알고리즘
+                        .compact();
+
+    }
+
+    public void addJwtToHeader(String tokenHeader, String token, HttpServletResponse res) {
+        res.addHeader(tokenHeader, token);
+    }
+
+    // token을 header에서 가져와서 반환하는 메서드
+    public String getTokenFromHeader(String tokenHeader, HttpServletRequest request) {
+        // header에서 token을 가져온다.
+        String token = request.getHeader(tokenHeader);
+        // 공백(null)인지 && BEARER로 시작을 하는지 확인
+        if (StringUtils.hasText(token) && token.startsWith(BEARER_PREFIX)) {
+            // 둘 다 만족할 경우 BEARER 뒤에 공백 길이만큼 잘라내고 순수한 토큰 값만을 리턴
+            return token.substring(BEARER_PREFIX.length());
+        }
+        return null;
+    }
+
+    // 토큰 검증
+    public boolean validateToken(String token) {
+        try {
+            Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token);
+            return true;
+        } catch (SecurityException | MalformedJwtException | SignatureException e) {
+            logger.error("Invalid JWT signature, 유효하지 않는 JWT 서명 입니다.");
+        } catch (ExpiredJwtException e) {
+            logger.error("Expired JWT token, 만료된 JWT token 입니다.");
+        } catch (UnsupportedJwtException e) {
+            logger.error("Unsupported JWT token, 지원되지 않는 JWT 토큰 입니다.");
+        } catch (IllegalArgumentException e) {
+            logger.error("JWT claims is empty, 잘못된 JWT 토큰 입니다.");
+        }
+        return false;
+    }
+
+    // 토큰에서 사용자 정보 가져오기
+    public Claims getUserInfoFromToken(String token) {
+        return Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token).getBody();
+    }
+
+}

--- a/src/main/java/com/sparta/spartakanbanboard/global/security/JwtAuthorizationFilter.java
+++ b/src/main/java/com/sparta/spartakanbanboard/global/security/JwtAuthorizationFilter.java
@@ -1,0 +1,77 @@
+package com.sparta.spartakanbanboard.global.security;
+
+import com.sparta.spartakanbanboard.global.jwt.JwtUtil;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@Slf4j(topic = "JWT 검증 및 인가")
+public class JwtAuthorizationFilter extends OncePerRequestFilter {
+
+    private final JwtUtil jwtUtil;
+    private final UserDetailsServiceImpl userDetailsService;
+
+    public JwtAuthorizationFilter(JwtUtil jwtUtil, UserDetailsServiceImpl userDetailsService) {
+        this.jwtUtil = jwtUtil;
+        this.userDetailsService = userDetailsService;
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest req, HttpServletResponse res, FilterChain filterChain) throws ServletException, IOException {
+
+        String tokenValue = jwtUtil.getTokenFromHeader(JwtUtil.AUTHORIZATION_HEADER, req);
+
+        if (StringUtils.hasText(tokenValue)) {
+            try {
+                if (!jwtUtil.validateToken(tokenValue)) {
+                    log.error("Token Error");
+                }
+
+                Claims info = jwtUtil.getUserInfoFromToken(tokenValue);
+                setAuthentication(info.getSubject());
+
+            } catch (ExpiredJwtException e) {
+                res.setStatus(HttpStatus.UNAUTHORIZED.value());
+                res.setContentType("application/json");
+                res.setCharacterEncoding("UTF-8");
+                res.getWriter().write("{\"message\":\"리프레시 토큰으로 재발급 받으세요\"}");
+
+                return;
+            } catch (Exception e) {
+                log.error(e.getMessage());
+                return;
+            }
+        }
+
+        filterChain.doFilter(req, res);
+    }
+
+    // 인증 처리
+    public void setAuthentication(String username) {
+        SecurityContext context = SecurityContextHolder.createEmptyContext();
+        Authentication authentication = createAuthentication(username);
+        context.setAuthentication(authentication);
+
+        SecurityContextHolder.setContext(context);
+    }
+
+    // 인증 객체 생성
+    private Authentication createAuthentication(String username) {
+        UserDetails userDetails = userDetailsService.loadUserByUsername(username);
+        return new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
+    }
+}

--- a/src/main/java/com/sparta/spartakanbanboard/global/security/UserDetailsImpl.java
+++ b/src/main/java/com/sparta/spartakanbanboard/global/security/UserDetailsImpl.java
@@ -1,0 +1,65 @@
+package com.sparta.spartakanbanboard.global.security;
+
+import com.sparta.spartakanbanboard.domain.user.entity.User;
+import com.sparta.spartakanbanboard.domain.user.entity.UserRole;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.ArrayList;
+import java.util.Collection;
+
+@RequiredArgsConstructor
+public class UserDetailsImpl implements UserDetails {
+
+    private final User user;
+
+    public User getUser() {
+        return user;
+    }
+
+    @Override
+    public String getPassword() {
+        return user.getPassword();
+    }
+
+    @Override
+    public String getUsername() {
+        return user.getUserName();
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+
+        UserRole role = user.getUserRole();
+        String roleString = role.getAuthority();
+
+        SimpleGrantedAuthority simpleGrantedAuthority = new SimpleGrantedAuthority(roleString);
+        Collection<GrantedAuthority> authorities = new ArrayList<>();
+        authorities.add(simpleGrantedAuthority);
+
+        return authorities;
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
+
+}

--- a/src/main/java/com/sparta/spartakanbanboard/global/security/UserDetailsServiceImpl.java
+++ b/src/main/java/com/sparta/spartakanbanboard/global/security/UserDetailsServiceImpl.java
@@ -1,0 +1,27 @@
+package com.sparta.spartakanbanboard.global.security;
+
+import com.sparta.spartakanbanboard.domain.user.entity.User;
+import com.sparta.spartakanbanboard.domain.user.repository.UserRepository;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+@Service
+public class UserDetailsServiceImpl implements UserDetailsService {
+
+    private final UserRepository userRepository;
+
+    public UserDetailsServiceImpl(UserRepository userRepository) {
+        this.userRepository = userRepository;
+    }
+
+    @Override
+    public UserDetails loadUserByUsername(String userName) throws UsernameNotFoundException {
+        User user = userRepository.findByUserName(userName)
+                .orElseThrow(() -> new UsernameNotFoundException("Not Found " + userName));
+
+        return new UserDetailsImpl(user);
+    }
+
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈
#13 , #15 

## 📝 작업 내용
시큐리티 구현 및 회원가입 기능 구현입니다.


### 📸 스크린샷 
- 회원가입 
![image](https://github.com/spartaKanbanBoard/spartaKanbanBoard/assets/166794538/78a78ddd-9a7c-48be-af1e-694c784529fb)
![image](https://github.com/spartaKanbanBoard/spartaKanbanBoard/assets/166794538/2f1173cb-6cd8-4801-9cf2-f9ed664c12cc)

- role값을 ADMIN으로 하였지만 adminToken이 잘못된 경우 
![image](https://github.com/spartaKanbanBoard/spartaKanbanBoard/assets/166794538/8972fb08-c6e1-47d1-82bf-63a92b91a122)

## 💬 리뷰 요구사항
- 아직 에러 헨들러가 없어서 로그에러로 뜹니다.
- 회원가입 시 아이디, 패스워드에 제약조건이 없었어서 일단 NOTNULL 만 걸었습니다.
- redis 적용 전까진 user entity에 리프레시 토큰 저장하겠습니다
