### PR TITLE
[2024/07/11] feat/login >> 로그인 기능구현

### DIFF
--- a/src/main/java/com/sparta/spartakanbanboard/domain/user/controller/UserController.java
+++ b/src/main/java/com/sparta/spartakanbanboard/domain/user/controller/UserController.java
@@ -1,11 +1,12 @@
 package com.sparta.spartakanbanboard.domain.user.controller;
 
+import com.sparta.spartakanbanboard.domain.user.dto.LoginRequestDto;
 import com.sparta.spartakanbanboard.domain.user.dto.SignupRequestDto;
 import com.sparta.spartakanbanboard.domain.user.service.UserService;
 import com.sparta.spartakanbanboard.global.dto.CommonResponseDto;
+import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -22,6 +23,12 @@ public class UserController {
     @PostMapping("/signup")
     public ResponseEntity<CommonResponseDto> signup(@RequestBody @Valid SignupRequestDto signupRequestDto) {
         CommonResponseDto responseDto = userService.signup(signupRequestDto);
+        return ResponseEntity.ok().body(responseDto);
+    }
+
+    @PostMapping("/login")
+    public ResponseEntity<CommonResponseDto> login(@Valid @RequestBody LoginRequestDto loginRequestDto, HttpServletResponse response) {
+        CommonResponseDto responseDto = userService.login(loginRequestDto, response);
         return ResponseEntity.ok().body(responseDto);
     }
 }

--- a/src/main/java/com/sparta/spartakanbanboard/domain/user/controller/UserController.java
+++ b/src/main/java/com/sparta/spartakanbanboard/domain/user/controller/UserController.java
@@ -21,8 +21,7 @@ public class UserController {
 
     @PostMapping("/signup")
     public ResponseEntity<CommonResponseDto> signup(@RequestBody @Valid SignupRequestDto signupRequestDto) {
-
         CommonResponseDto responseDto = userService.signup(signupRequestDto);
-        return ResponseEntity.status(HttpStatus.OK).body(responseDto);
+        return ResponseEntity.ok().body(responseDto);
     }
 }

--- a/src/main/java/com/sparta/spartakanbanboard/domain/user/entity/User.java
+++ b/src/main/java/com/sparta/spartakanbanboard/domain/user/entity/User.java
@@ -34,4 +34,16 @@ public class User {
 
     @Column
     private String refreshToken;
+
+    public void updateRefreshToken(String refreshToken) {
+        this.refreshToken = refreshToken;
+    }
+
+    public void login() {
+        this.userStatus = UserStatus.ACTIVE;
+    }
+
+    public void logout() {
+        this.userStatus = UserStatus.LOGOUT;
+    }
 }

--- a/src/main/java/com/sparta/spartakanbanboard/domain/user/service/UserService.java
+++ b/src/main/java/com/sparta/spartakanbanboard/domain/user/service/UserService.java
@@ -1,12 +1,15 @@
 package com.sparta.spartakanbanboard.domain.user.service;
 
+import com.sparta.spartakanbanboard.domain.user.dto.LoginRequestDto;
 import com.sparta.spartakanbanboard.domain.user.dto.SignupRequestDto;
 import com.sparta.spartakanbanboard.domain.user.entity.User;
 import com.sparta.spartakanbanboard.domain.user.entity.UserRole;
 import com.sparta.spartakanbanboard.domain.user.entity.UserStatus;
 import com.sparta.spartakanbanboard.domain.user.repository.UserRepository;
+import com.sparta.spartakanbanboard.global.BusinessLogicException;
 import com.sparta.spartakanbanboard.global.dto.CommonResponseDto;
 import com.sparta.spartakanbanboard.global.jwt.JwtUtil;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -28,14 +31,14 @@ public class UserService {
         UserRole userRole = UserRole.USER;
 
         if (userRepository.findByUserName(userName).isPresent()) {
-            throw new RuntimeException("중복된 사용자 ID가 존재합니다.");
+            throw new BusinessLogicException("중복된 사용자 ID가 존재합니다.");
         }
 
         if (signupRequestDto.getRole().equals("ADMIN")) {
             if (signupRequestDto.getAdminToken() != null && signupRequestDto.getAdminToken().equals(adminToken)) {
                 userRole = UserRole.ADMIN;
             } else {
-                throw new IllegalArgumentException("adminToken이 올바르지 않습니다.");
+                throw new BusinessLogicException("adminToken이 올바르지 않습니다.");
             }
         }
 
@@ -53,9 +56,34 @@ public class UserService {
                 .build();
     }
 
-    public User findByUserId(Long userId) {
-        return userRepository.findById(userId).orElseThrow(() ->
-                new IllegalArgumentException("해당 유저를 찾을 수 없습니다"));
+    public CommonResponseDto login(LoginRequestDto requestDto, HttpServletResponse response) {
+        User user = userRepository.findByUserName(requestDto.getUserName())
+                .orElseThrow(() -> new BusinessLogicException("사용자를 찾을 수 없습니다."));
+
+
+        if (!passwordEncoder.matches(requestDto.getPassword(), user.getPassword())) {
+            throw new BusinessLogicException("잘못된 비밀번호입니다.");
+        }
+        String accessToken = jwtUtil.createAccessToken(user.getUserName(),user.getUserRole());
+        String refreshToken = jwtUtil.createRefreshToken(user.getUserName());
+
+        // DB에 토큰 저장 및 유저 상태 변경
+        user.updateRefreshToken(refreshToken);
+        user.login();
+        userRepository.save(user);
+
+        // 헤더에 추가
+        jwtUtil.addJwtToHeader(JwtUtil.AUTHORIZATION_HEADER, accessToken, response);
+        jwtUtil.addJwtToHeader(JwtUtil.REFRESH_HEADER, refreshToken, response);
+
+        return CommonResponseDto.builder()
+                .msg("로그인 되었습니다")
+                .data(accessToken)
+                .build();
     }
 
+    public User findByUserId(Long userId) {
+        return userRepository.findById(userId).orElseThrow(() ->
+                new BusinessLogicException("해당 유저를 찾을 수 없습니다"));
+    }
 }

--- a/src/main/java/com/sparta/spartakanbanboard/global/jwt/JwtUtil.java
+++ b/src/main/java/com/sparta/spartakanbanboard/global/jwt/JwtUtil.java
@@ -61,13 +61,12 @@ public class JwtUtil {
                         .compact();
     }
 
-    public String createRefreshToken(String userName, UserRole userRole) {
+    public String createRefreshToken(String userName) {
         Date date = new Date();
 
         return BEARER_PREFIX +
                 Jwts.builder()
                         .setSubject(userName) // 사용자 식별자값(ID)
-                        .claim(AUTHORIZATION_KEY, userRole) // 사용자 권한
                         .setExpiration(new Date(date.getTime() + REFRESHTOKEN_TIME)) // 만료 시간
                         .setIssuedAt(date) // 발급일
                         .signWith(key, signatureAlgorithm) // 암호화 알고리즘


### PR DESCRIPTION
## #️⃣ 연관된 이슈

#15 

## 📝 작업 내용
로그인 기능 구현
리프레시 토큰 및 액세스 토큰 발급
리프레시 토큰은 발급시에 유저ID만 이용

### 📸 스크린샷 
- 로그인
![image](https://github.com/spartaKanbanBoard/spartaKanbanBoard/assets/166794538/7112efc0-d13f-4c2f-8499-58b3bcf7500e)
- 로그인시 리프레시 토큰 및 유저상태 DB 반영
![image](https://github.com/spartaKanbanBoard/spartaKanbanBoard/assets/166794538/e85ff263-bf1c-45c9-9480-7b8203fc06c1)



## 💬 리뷰 요구사항
- 로그인 response를 액세스 토큰 값을 data에 넣었는데 data값을 없애거나 리프레시토큰도 같이 보여주는게 좋을까요??


