### PR TITLE
댓글 삭제 기능구현, 본인만 가능

### DIFF
--- a/src/main/java/com/sparta/spartakanbanboard/domain/card/dto/EditCardRequestDto.java
+++ b/src/main/java/com/sparta/spartakanbanboard/domain/card/dto/EditCardRequestDto.java
@@ -4,10 +4,14 @@ import com.fasterxml.jackson.annotation.JsonFormat;
 import com.sparta.spartakanbanboard.domain.card.entity.State;
 import jakarta.validation.constraints.NotBlank;
 import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import org.springframework.format.annotation.DateTimeFormat;
 
 @Getter
+@Builder
+@AllArgsConstructor
 public class EditCardRequestDto {
 
     private Long cardId;

--- a/src/main/java/com/sparta/spartakanbanboard/domain/cardcomment/controller/CardCommentController.java
+++ b/src/main/java/com/sparta/spartakanbanboard/domain/cardcomment/controller/CardCommentController.java
@@ -1,6 +1,7 @@
 package com.sparta.spartakanbanboard.domain.cardcomment.controller;
 
 import com.sparta.spartakanbanboard.domain.cardcomment.dto.CreateCommentRequestDto;
+import com.sparta.spartakanbanboard.domain.cardcomment.dto.DeleteCommentRequestDto;
 import com.sparta.spartakanbanboard.domain.cardcomment.dto.EditCommentRequestDto;
 import com.sparta.spartakanbanboard.domain.cardcomment.service.CardCommentServiceImpl;
 import com.sparta.spartakanbanboard.global.dto.CommonResponseDto;
@@ -9,6 +10,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -55,6 +57,18 @@ public class CardCommentController {
 	) {
 		CommonResponseDto<?> commonResponseDto = cardCommentService.editComment(cardId,
 			editCommentRequestDto, userDetails);
+
+		return ResponseEntity.ok().body(commonResponseDto);
+	}
+
+	@DeleteMapping
+	public ResponseEntity<?> deleteComment(
+		@PathVariable Long cardId,
+		@RequestBody @Valid DeleteCommentRequestDto deleteCommentRequestDto,
+		@AuthenticationPrincipal UserDetailsImpl userDetails
+	) {
+		CommonResponseDto<?> commonResponseDto = cardCommentService.deleteComment(cardId,
+			deleteCommentRequestDto, userDetails);
 
 		return ResponseEntity.ok().body(commonResponseDto);
 	}

--- a/src/main/java/com/sparta/spartakanbanboard/domain/cardcomment/dto/DeleteCommentRequestDto.java
+++ b/src/main/java/com/sparta/spartakanbanboard/domain/cardcomment/dto/DeleteCommentRequestDto.java
@@ -1,0 +1,9 @@
+package com.sparta.spartakanbanboard.domain.cardcomment.dto;
+
+import lombok.Getter;
+
+@Getter
+public class DeleteCommentRequestDto {
+
+	private Long commentId;
+}

--- a/src/main/java/com/sparta/spartakanbanboard/domain/cardcomment/service/CardCommentService.java
+++ b/src/main/java/com/sparta/spartakanbanboard/domain/cardcomment/service/CardCommentService.java
@@ -1,6 +1,7 @@
 package com.sparta.spartakanbanboard.domain.cardcomment.service;
 
 import com.sparta.spartakanbanboard.domain.cardcomment.dto.CreateCommentRequestDto;
+import com.sparta.spartakanbanboard.domain.cardcomment.dto.DeleteCommentRequestDto;
 import com.sparta.spartakanbanboard.domain.cardcomment.dto.EditCommentRequestDto;
 import com.sparta.spartakanbanboard.domain.cardcomment.entity.CardComment;
 import com.sparta.spartakanbanboard.global.dto.CommonResponseDto;
@@ -20,6 +21,10 @@ public interface CardCommentService {
 	CommonResponseDto<?> editComment(Long cardId,
 		EditCommentRequestDto editCommentRequestDto, UserDetailsImpl userDetails
 	);
+
+	@Transactional
+	CommonResponseDto<?> deleteComment(Long cardId, DeleteCommentRequestDto deleteCommentRequestDto,
+		UserDetailsImpl userDetails);
 
 	CardComment findById(Long commentId);
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

본인 댓글을 아닌것을 삭제할시, 카드도 마찬가지 입니다.
IllegalArgumentException 을 타고 500에러가 나오네요.
인지하고있으니 해결해볼께요 

## 📝 작업 내용


### 📸 스크린샷 (선택)
삭제 댓글 생성
<img width="956" alt="스크린샷 2024-07-13 오후 9 25 54" src="https://github.com/user-attachments/assets/b0a28a64-dde0-43f9-ac85-44f9d2f4e234">

삭제 성공

<img width="733" alt="스크린샷 2024-07-13 오후 9 26 05" src="https://github.com/user-attachments/assets/467a09d3-7013-418c-a7d5-cbc25679a7d4">

삭제 성공 후 조회
<img width="947" alt="스크린샷 2024-07-13 오후 9 26 16" src="https://github.com/user-attachments/assets/463be126-a67c-4ee5-a378-021cce2dd5c4">

다른 사용자가 삭제할 시 오류 발견 카드도 마찬가지입니다.
<img width="704" alt="스크린샷 2024-07-13 오후 9 53 48" src="https://github.com/user-attachments/assets/99cd24fd-48b6-4942-9dd5-1a29054f518e">



## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
